### PR TITLE
Better transmit event info such as cancellation statuses

### DIFF
--- a/src/main/java/de/themoep/snap/forwarding/listener/ChatListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ChatListener.java
@@ -33,10 +33,16 @@ public class ChatListener extends ForwardingListener {
     @Subscribe
     public void on(PlayerChatEvent event) {
         SnapPlayer player = snap.getPlayer(event.getPlayer());
-        ChatEvent e = snap.getBungeeAdapter().getPluginManager().callEvent(new ChatEvent(player, player.getServer(), event.getMessage()));
+
+        ChatEvent e = new ChatEvent(
+                player, player.getServer(),
+                event.getResult().getMessage().orElse(event.getMessage())
+        );
+        e.setCancelled(!event.getResult().isAllowed());
+        snap.getBungeeAdapter().getPluginManager().callEvent(e);
         if (e.isCancelled()) {
             event.setResult(PlayerChatEvent.ChatResult.denied());
-        } else if (!e.getMessage().equals(event.getMessage())) {
+        } else {
             event.setResult(PlayerChatEvent.ChatResult.message(e.getMessage()));
         }
     }

--- a/src/main/java/de/themoep/snap/forwarding/listener/ClientConnectListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ClientConnectListener.java
@@ -41,7 +41,12 @@ public class ClientConnectListener extends ForwardingListener {
         e.setCancelled(!event.getResult().isAllowed());
         snap.getBungeeAdapter().getPluginManager().callEvent(e);
         if (e.isCancelled()) {
-            event.setResult(PreLoginEvent.PreLoginComponentResult.denied(Component.text("ClientConnectEvent Cancelled")));
+            boolean originallyAllowed = event.getResult().isAllowed();
+            if (originallyAllowed) {
+                event.setResult(PreLoginEvent.PreLoginComponentResult.denied(Component.text("ClientConnectEvent Cancelled")));
+            }
+        } else {
+            event.setResult(PreLoginEvent.PreLoginComponentResult.allowed());
         }
     }
 }

--- a/src/main/java/de/themoep/snap/forwarding/listener/ClientConnectListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ClientConnectListener.java
@@ -34,10 +34,12 @@ public class ClientConnectListener extends ForwardingListener {
 
     @Subscribe(order = PostOrder.FIRST)
     public void on(PreLoginEvent event) {
-        ClientConnectEvent e = snap.getBungeeAdapter().getPluginManager().callEvent(new ClientConnectEvent(
+        ClientConnectEvent e = new ClientConnectEvent(
                 event.getConnection().getRemoteAddress(),
                 snap.getBungeeAdapter().getProxy().getListener()
-        ));
+        );
+        e.setCancelled(!event.getResult().isAllowed());
+        snap.getBungeeAdapter().getPluginManager().callEvent(e);
         if (e.isCancelled()) {
             event.setResult(PreLoginEvent.PreLoginComponentResult.denied(Component.text("ClientConnectEvent Cancelled")));
         }

--- a/src/main/java/de/themoep/snap/forwarding/listener/ServerDisconnectListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ServerDisconnectListener.java
@@ -33,6 +33,9 @@ public class ServerDisconnectListener extends ForwardingListener {
 
     @Subscribe(order = PostOrder.LAST)
     public void on(KickedFromServerEvent event) {
+        if (!event.getResult().isAllowed()) {
+            return;
+        }
         snap.getBungeeAdapter().getPluginManager().callEvent(new ServerDisconnectEvent(
                 snap.getPlayer(event.getPlayer()),
                 snap.getServerInfo(event.getServer())

--- a/src/main/java/de/themoep/snap/forwarding/listener/ServerDisconnectListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ServerDisconnectListener.java
@@ -33,9 +33,6 @@ public class ServerDisconnectListener extends ForwardingListener {
 
     @Subscribe(order = PostOrder.LAST)
     public void on(KickedFromServerEvent event) {
-        if (!event.getResult().isAllowed()) {
-            return;
-        }
         snap.getBungeeAdapter().getPluginManager().callEvent(new ServerDisconnectEvent(
                 snap.getPlayer(event.getPlayer()),
                 snap.getServerInfo(event.getServer())


### PR DESCRIPTION
A user claimed that BungeeChat, a chat plugin on BungeeCord, continued to broadcast messages despite the chat event's cancellation by a punishment plugin on Velocity.

I found that BungeeChat *does* respect the cancellation status of the event, but Snap wasn't transmitting the cancellation of the Velocity chat event to the BungeeCord event.

I looked through the forwarding listeners and found a few other cases where it seemed that some event information was left off during the BungeeCord<->Velocity event conversion.