### PR TITLE
fix: Resolve Issue #54 and upgrade to Java 21 / Velocity 3.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out
 gen
 target/
 dependency-reduced-pom.xml
+bin/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Snap!
+# Snap! 2.0 Beta (Java 21 Edition)
 
 This is the Seriously Necessary Adapter Plugin to enable plugins written against the
  BungeeCord or Waterfall API to load and (kinda) run on [Velocity](https://velocitypowered.com/). 👀
+ 
+ 🎉 **Now natively modernized for Velocity 3.5.0+ and Java 21**, with massive compatibility fixes!
 
 ## How?
 
@@ -64,7 +66,7 @@ If you are sure that the plugin will work fine otherwise then you can have it re
   Bungee. They are as close as possible though but if you already have to fiddle with 
   that then its best to create a standalone Velocity plugin tbh.
 - Some events don't work 100% or not at all.  
-  Not working: `TabCompleteEvent`, `ProxyDefineCommandEvent`, `ProxyExceptionEvent`.  
+  Not working: `ProxyDefineCommandEvent`, `ProxyExceptionEvent`.  
   Only partially: `ServerDisconnectEvent` (only triggers on kicks),
   `ClientConnectEvent` (uses Velocity's `LoginEvent` with `PostOrder.FIRST`)
   `ConnectionInitEvent` (uses Velocity's `LoginEvent` with `PostOrder.EARLY`)
@@ -72,8 +74,8 @@ If you are sure that the plugin will work fine otherwise then you can have it re
 
 ## Sounds awesome! How can I get it?
 
-You can download the jar via [GitHub releases](https://github.com/Phoenix616/Snap/releases)
- or get builds from the latest commits from the [Minebench.de Jenkins](https://ci.minebench.de/job/Snap/).
+You can download the jar via [GitHub releases](https://github.com/tush2912/Snap/releases)
+ or get builds from the latest commits from your build process.
  
 ## How can I support the project?
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# Snap! 2.0 Beta (Java 21 Edition)
+# Snap!
 
 This is the Seriously Necessary Adapter Plugin to enable plugins written against the
  BungeeCord or Waterfall API to load and (kinda) run on [Velocity](https://velocitypowered.com/). 👀
- 
- 🎉 **Now natively modernized for Velocity 3.5.0+ and Java 21**, with massive compatibility fixes!
 
 ## How?
 
 Simply add the Bungee plugins into the plugins folder inside the Snap plugin folder.
 
-Snap will use it's own instance of BungeeCord's plugin manager to load the plugins 
+Snap will use its own instance of BungeeCord's plugin manager to load the plugins 
  from there and translate BungeeCord methods, classes as well as event calls to the 
  respective Velocity ones and vice versa.
 
@@ -19,7 +17,7 @@ Originally I wanted to document the Velocity equivalents to Bungee events, metho
  and classes. This evolved into the idea of writing a converter for source code which
  led me to decide to try to make a plugin which can directly load Bungee plugins.
  
-Seeing as the proxies don't have too much logic that seems to have worked although
+Seeing as the proxies don't have too much logic that seems to have worked, although
  it is definitely a lot more inefficient than just running native Velocity plugins 
  due lots of classes being in need of getting translated on the fly.
  
@@ -52,7 +50,7 @@ If you are sure that the plugin will work fine otherwise then you can have it re
 - **Reconnect server functionality.** That's an inbuilt function in Bungee but better 
   suited for a plugin. The related methods will return `null` or set nothing. Instead
   of erroring.
-- **Scoreboards.** Velocity doesn't have API for them and I'm not going to create a 
+- **Scoreboards.** Velocity doesn't have API for them, and I'm not going to create a 
   packet based one. Maybe there will be a way to integrate in some plugin or Velocity 
   adds support in the future.
 - Some **ProxyConfig** settings don't exist on Velocity or aren't exposed in the API so 
@@ -64,25 +62,26 @@ If you are sure that the plugin will work fine otherwise then you can have it re
   PluginManager APIs and as dependencies. Their classes should be accessible though.
 - Some connection handling and related events might not work 100% exactly like on 
   Bungee. They are as close as possible though but if you already have to fiddle with 
-  that then its best to create a standalone Velocity plugin tbh.
+  that then it's best to create a standalone Velocity plugin tbh.
+- Transfer detection only works in online-mode
 - Some events don't work 100% or not at all.  
   Not working: `ProxyDefineCommandEvent`, `ProxyExceptionEvent`.  
-  Only partially: `ServerDisconnectEvent` (only triggers on kicks),
+  Only partially: `TabCompleteEvent` and `TabCompleteResponseEvent` (only work on 1.21.2 or below), `ServerDisconnectEvent` (only triggers on kicks),
   `ClientConnectEvent` (uses Velocity's `LoginEvent` with `PostOrder.FIRST`)
   `ConnectionInitEvent` (uses Velocity's `LoginEvent` with `PostOrder.EARLY`)
 - **Unsafe** doesn't work.
 
 ## Sounds awesome! How can I get it?
 
-You can download the jar via [GitHub releases](https://github.com/tush2912/Snap/releases)
- or get builds from the latest commits from your build process.
+You can download the jar via [GitHub releases](https://github.com/Phoenix616/Snap/releases)
+ or get builds from the latest commits from the [Minebench.de Jenkins](https://ci.minebench.de/job/Snap/).
  
 ## How can I support the project?
 
 For the start trying out the plugin and reporting what other plugins work and don't work
  would already help a ton figuring out what work is still needed.
  
-Of course I would also appreciate [monetary help](https://tip.phoenix616.dev) if the plugin
+Of course, I would also appreciate [monetary help](https://tip.phoenix616.dev) if the plugin
  has helped you transition to Velocity either by directly using it or referencing its code to 
  adapt Bungee plugins to get running on Velocity natively. (Did you know that GitHub is still 
  doubling donations to [my GitHub Sponsors page](https://ghsponsor.phoenix616.dev)? 😉)

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
 
     <groupId>de.themoep</groupId>
     <artifactId>snap</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>2.0-Beta</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <build.number>${buildNumber}</build.number>
         <minecraft.plugin.version>${project.version} ${buildDescription}</minecraft.plugin.version>
     </properties>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.3.0-SNAPSHOT</version>
+            <version>3.5.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -114,7 +114,7 @@
 
 
     <build>
-        <finalName>${project.name}</finalName>
+        <finalName>Snap 2.0 Beta</finalName>
         <resources>
             <resource>
                 <filtering>true</filtering>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.themoep</groupId>
     <artifactId>snap</artifactId>
-    <version>2.0-Beta</version>
+    <version>2.0-RC1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -114,7 +114,7 @@
 
 
     <build>
-        <finalName>Snap 2.0 Beta</finalName>
+        <finalName>Snap 2.0 RC1</finalName>
         <resources>
             <resource>
                 <filtering>true</filtering>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.themoep</groupId>
     <artifactId>snap</artifactId>
-    <version>2.0-RC1</version>
+    <version>1.3-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -114,7 +114,7 @@
 
 
     <build>
-        <finalName>Snap 2.0 RC1</finalName>
+        <finalName>${project.name}</finalName>
         <resources>
             <resource>
                 <filtering>true</filtering>

--- a/src/main/java/de/themoep/snap/Snap.java
+++ b/src/main/java/de/themoep/snap/Snap.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +43,6 @@ public class Snap {
     private final Map<UUID, SnapPlayer> players = new ConcurrentHashMap<>();
     private final Map<String, SnapPlayer> playerNames = new ConcurrentHashMap<>();
     private final Map<String, SnapServerInfo> servers = new ConcurrentHashMap<>();
-    private final Set<UUID> transferred = ConcurrentHashMap.newKeySet();
 
     private final Table<UUID, Key, CompletableFuture<byte[]>> cookieRequests = HashBasedTable.create();
 
@@ -164,7 +162,6 @@ public class Snap {
         players.remove(player.getUniqueId());
         playerNames.remove(player.getUsername());
         cookieRequests.row(player.getUniqueId()).clear();
-        transferred.remove(player.getUniqueId());
     }
 
     public CompletableFuture<byte[]> retrieveCookie(InboundConnection connection, String key) {
@@ -194,13 +191,5 @@ public class Snap {
             return true;
         }
         return false;
-    }
-
-    public void markTransferred(Player player) {
-        transferred.add(player.getUniqueId());
-    }
-
-    public boolean isTransferred(UUID playerId) {
-        return transferred.contains(playerId);
     }
 }

--- a/src/main/java/de/themoep/snap/SnapBungeeAdapter.java
+++ b/src/main/java/de/themoep/snap/SnapBungeeAdapter.java
@@ -51,6 +51,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.event.EventBus;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 
@@ -87,9 +88,25 @@ public class SnapBungeeAdapter {
         pluginManager = new PluginManager(snapProxy);
 
         // Replace Yaml instance with one with proper class loader
+        // Use reflection to handle both SnakeYAML 1.x and 2.x constructors
         Field fYaml = pluginManager.getClass().getDeclaredField("yaml");
         fYaml.setAccessible(true);
-        org.yaml.snakeyaml.constructor.Constructor constructor = new CustomClassLoaderConstructor(snap.getClass().getClassLoader());
+        org.yaml.snakeyaml.constructor.Constructor constructor;
+        try {
+            // SnakeYAML 2.x: CustomClassLoaderConstructor(ClassLoader, LoaderOptions)
+            java.lang.reflect.Constructor<?> ctor = CustomClassLoaderConstructor.class
+                    .getConstructor(ClassLoader.class, LoaderOptions.class);
+            constructor = (org.yaml.snakeyaml.constructor.Constructor) ctor.newInstance(snap.getClass().getClassLoader(), new LoaderOptions());
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            // SnakeYAML 1.x: CustomClassLoaderConstructor(ClassLoader)
+            try {
+                java.lang.reflect.Constructor<?> ctor = CustomClassLoaderConstructor.class
+                        .getConstructor(ClassLoader.class);
+                constructor = (org.yaml.snakeyaml.constructor.Constructor) ctor.newInstance(snap.getClass().getClassLoader());
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to initialize SnakeYAML", ex);
+            }
+        }
         PropertyUtils properties = constructor.getPropertyUtils();
         properties.setSkipMissingProperties(true);
         constructor.setPropertyUtils(properties);
@@ -130,7 +147,7 @@ public class SnapBungeeAdapter {
         addListener(new ServerKickListener(snap));
         addListener(new ServerSwitchListener(snap));
         addListener(new SettingsChangedListener(snap));
-        // TODO addListener(tnew TabCompleteListener(snap)); no real Velocity equivalent
+        addListener(new de.themoep.snap.forwarding.listener.TabCompleteListener(snap));
         addListener(new TabCompleteResponseListener(snap));
     }
 

--- a/src/main/java/de/themoep/snap/SnapListener.java
+++ b/src/main/java/de/themoep/snap/SnapListener.java
@@ -18,16 +18,12 @@ package de.themoep.snap;
  * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
-import com.velocitypowered.api.event.connection.ConnectionHandshakeEvent;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.player.CookieReceiveEvent;
 import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
-import com.velocitypowered.api.network.HandshakeIntent;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.util.GameProfile;
 
 import java.util.UUID;
@@ -42,21 +38,14 @@ public class SnapListener {
         this.snap = snap;
     }
 
-    @Subscribe
-    public void onHandshake(ConnectionHandshakeEvent event) {
-        if (event.getIntent() == HandshakeIntent.TRANSFER && event.getConnection() instanceof Player player) {
-            snap.markTransferred(player);
-        }
-    }
-
-    @Subscribe(order = PostOrder.FIRST)
+    @Subscribe(priority = -100)
     public void onPlayerConnect(LoginEvent event) {
         if (event.getResult().isAllowed()) {
             snap.getPlayer(event.getPlayer());
         }
     }
 
-    @Subscribe(order = PostOrder.LAST)
+    @Subscribe(priority = 100)
     public void onPlayerConnectLast(LoginEvent event) {
         if (!event.getResult().isAllowed()) {
             snap.getPlayers().remove(event.getPlayer().getUniqueId());
@@ -64,7 +53,7 @@ public class SnapListener {
         }
     }
 
-    @Subscribe(order = PostOrder.LAST)
+    @Subscribe(priority = 100)
     public void onPlayerQuit(DisconnectEvent event) {
         snap.invalidate(event.getPlayer());
     }

--- a/src/main/java/de/themoep/snap/forwarding/SnapPlayer.java
+++ b/src/main/java/de/themoep/snap/forwarding/SnapPlayer.java
@@ -155,6 +155,12 @@ public class SnapPlayer extends SnapCommandSender implements ProxiedPlayer {
             public Unsafe unsafe() {
                 return (Unsafe) snap.unsupported("Unsafe is not supported by Snap!");
             }
+
+            @Override
+            public CompletableFuture<byte[]> sendData(String channel, byte[] data) {
+                SnapPlayer.this.sendData(channel, data);
+                return CompletableFuture.completedFuture(new byte[0]);
+            }
         };
         displayName = player.getUsername();
     }

--- a/src/main/java/de/themoep/snap/forwarding/SnapPlayer.java
+++ b/src/main/java/de/themoep/snap/forwarding/SnapPlayer.java
@@ -18,6 +18,7 @@ package de.themoep.snap.forwarding;
  * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.ModInfo;
@@ -113,7 +114,7 @@ public class SnapPlayer extends SnapCommandSender implements ProxiedPlayer {
 
             @Override
             public boolean isTransferred() {
-                return snap.isTransferred(player.getUniqueId());
+                return player.getHandshakeIntent() == HandshakeIntent.TRANSFER;
             }
 
             @Override

--- a/src/main/java/de/themoep/snap/forwarding/SnapProxyServer.java
+++ b/src/main/java/de/themoep/snap/forwarding/SnapProxyServer.java
@@ -303,7 +303,10 @@ public class SnapProxyServer extends ProxyServer {
 
     @Override
     public ServerInfo constructServerInfo(String name, SocketAddress address, String motd, boolean restricted) {
-        return constructServerInfo(name, (InetSocketAddress) address, motd, restricted);
+        if (address instanceof InetSocketAddress inetSocketAddress) {
+            return constructServerInfo(name, inetSocketAddress, motd, restricted);
+        }
+        return (ServerInfo) snap.unsupported("Cannot construct server info from " + address.getClass().getName());
     }
 
     @Override

--- a/src/main/java/de/themoep/snap/forwarding/SnapProxyServer.java
+++ b/src/main/java/de/themoep/snap/forwarding/SnapProxyServer.java
@@ -297,14 +297,13 @@ public class SnapProxyServer extends ProxyServer {
 
     @Override
     public ServerInfo constructServerInfo(String name, InetSocketAddress address, String motd, boolean restricted) {
-        // TODO: Server info support
-        return (ServerInfo) snap.unsupported();
+        com.velocitypowered.api.proxy.server.ServerInfo velocityInfo = new com.velocitypowered.api.proxy.server.ServerInfo(name, address);
+        return snap.getServerInfo(snap.getProxy().registerServer(velocityInfo));
     }
 
     @Override
     public ServerInfo constructServerInfo(String name, SocketAddress address, String motd, boolean restricted) {
-        // TODO: Server info support
-        return (ServerInfo) snap.unsupported();
+        return constructServerInfo(name, (InetSocketAddress) address, motd, restricted);
     }
 
     @Override

--- a/src/main/java/de/themoep/snap/forwarding/listener/ForwardingListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ForwardingListener.java
@@ -144,6 +144,12 @@ public abstract class ForwardingListener {
             public Unsafe unsafe() {
                 return (Unsafe) snap.unsupported("Unsafe is not supported in Snap!");
             }
+
+            @Override
+            public CompletableFuture<byte[]> sendData(String channel, byte[] data) {
+                // Not supported for generic InboundConnection
+                return CompletableFuture.completedFuture(new byte[0]);
+            }
         };
     }
 }

--- a/src/main/java/de/themoep/snap/forwarding/listener/ForwardingListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/ForwardingListener.java
@@ -18,9 +18,12 @@ package de.themoep.snap.forwarding.listener;
  * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import com.velocitypowered.api.network.HandshakeIntent;
 import com.velocitypowered.api.proxy.InboundConnection;
+import com.velocitypowered.api.proxy.LoginPhaseConnection;
 import com.velocitypowered.api.proxy.Player;
 import de.themoep.snap.Snap;
+import de.themoep.snap.SnapUtils;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
@@ -45,6 +48,10 @@ public abstract class ForwardingListener {
     }
 
     protected PendingConnection convertConnection(InboundConnection connection) {
+        if (connection instanceof Player player) {
+            return snap.getPlayer(player).getPendingConnection();
+        }
+
         return new PendingConnection() {
             @Override
             public String getName() {
@@ -98,11 +105,7 @@ public abstract class ForwardingListener {
 
             @Override
             public boolean isTransferred() {
-                if (connection instanceof Player player) {
-                    return snap.isTransferred(player.getUniqueId());
-                }
-                snap.unsupported("Tried to check an InboundConnection which is not a Player (" + connection.getClass().getName() + ") for whether it was transferred!");
-                return false;
+                return connection.getHandshakeIntent() == HandshakeIntent.TRANSFER;
             }
 
             @Override
@@ -147,7 +150,13 @@ public abstract class ForwardingListener {
 
             @Override
             public CompletableFuture<byte[]> sendData(String channel, byte[] data) {
+                if (connection instanceof LoginPhaseConnection loginPhaseConnection) {
+                    CompletableFuture<byte[]> future = new CompletableFuture<>();
+                    loginPhaseConnection.sendLoginPluginMessage(SnapUtils.createChannelIdentifier(channel), data, future::complete);
+                    return future;
+                }
                 // Not supported for generic InboundConnection
+                snap.unsupported("Cannot send plugin message data for " + connection.getClass().getSimpleName() + " in Snap!");
                 return CompletableFuture.completedFuture(new byte[0]);
             }
         };

--- a/src/main/java/de/themoep/snap/forwarding/listener/PreLoginListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/PreLoginListener.java
@@ -20,7 +20,10 @@ package de.themoep.snap.forwarding.listener;
 
 import com.velocitypowered.api.event.Continuation;
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.network.HandshakeIntent;
+import com.velocitypowered.api.proxy.LoginPhaseConnection;
 import de.themoep.snap.Snap;
+import de.themoep.snap.SnapUtils;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -110,7 +113,7 @@ public class PreLoginListener extends ForwardingListener {
 
             @Override
             public boolean isTransferred() {
-                return snap.isTransferred(event.getUniqueId());
+                return event.getConnection().getHandshakeIntent() == HandshakeIntent.TRANSFER;
             }
 
             @Override
@@ -155,7 +158,13 @@ public class PreLoginListener extends ForwardingListener {
 
             @Override
             public CompletableFuture<byte[]> sendData(String channel, byte[] data) {
-                // Not supported during pre-login
+                if (event.getConnection() instanceof LoginPhaseConnection loginPhaseConnection) {
+                    CompletableFuture<byte[]> future = new CompletableFuture<>();
+                    loginPhaseConnection.sendLoginPluginMessage(SnapUtils.createChannelIdentifier(channel), data, future::complete);
+                    return future;
+                }
+                // Not supported for generic InboundConnection
+                snap.unsupported("Cannot send plugin message data for " + event.getConnection().getClass().getSimpleName() + " during the PreLoginEvent in Snap!");
                 return CompletableFuture.completedFuture(new byte[0]);
             }
         }, (e, t) -> {

--- a/src/main/java/de/themoep/snap/forwarding/listener/PreLoginListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/PreLoginListener.java
@@ -152,6 +152,12 @@ public class PreLoginListener extends ForwardingListener {
             public Unsafe unsafe() {
                 return (Unsafe) snap.unsupported("Unsafe is not supported in Snap!");
             }
+
+            @Override
+            public CompletableFuture<byte[]> sendData(String channel, byte[] data) {
+                // Not supported during pre-login
+                return CompletableFuture.completedFuture(new byte[0]);
+            }
         }, (e, t) -> {
             if (e.isCancelled()) {
                 event.setResult(com.velocitypowered.api.event.connection.PreLoginEvent.PreLoginComponentResult.denied(

--- a/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteListener.java
@@ -1,0 +1,26 @@
+package de.themoep.snap.forwarding.listener;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.TabCompleteEvent;
+import de.themoep.snap.Snap;
+import de.themoep.snap.forwarding.SnapServer;
+
+public class TabCompleteListener extends ForwardingListener {
+
+    public TabCompleteListener(Snap snap) {
+        super(snap, net.md_5.bungee.api.event.TabCompleteEvent.class);
+    }
+
+    @Subscribe
+    public void on(com.velocitypowered.api.event.player.TabCompleteEvent event) {
+        net.md_5.bungee.api.event.TabCompleteEvent e = snap.getBungeeAdapter().getPluginManager().callEvent(new net.md_5.bungee.api.event.TabCompleteEvent(
+                snap.getPlayer(event.getPlayer()),
+                event.getPlayer().getCurrentServer().map(s -> new SnapServer(snap, s)).orElse(null),
+                event.getPartialMessage(),
+                event.getSuggestions()
+        ));
+        if (e.isCancelled()) {
+            event.getSuggestions().clear();
+        }
+    }
+}

--- a/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteListener.java
@@ -1,7 +1,24 @@
 package de.themoep.snap.forwarding.listener;
 
+/*
+ * Snap
+ * Copyright (c) 2021 Max Lee aka Phoenix616 (max@themoep.de)
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import com.velocitypowered.api.event.Subscribe;
-import com.velocitypowered.api.event.player.TabCompleteEvent;
 import de.themoep.snap.Snap;
 import de.themoep.snap.forwarding.SnapServer;
 
@@ -11,7 +28,7 @@ public class TabCompleteListener extends ForwardingListener {
         super(snap, net.md_5.bungee.api.event.TabCompleteEvent.class);
     }
 
-    @Subscribe
+    @Subscribe(priority = 10)
     public void on(com.velocitypowered.api.event.player.TabCompleteEvent event) {
         net.md_5.bungee.api.event.TabCompleteEvent e = snap.getBungeeAdapter().getPluginManager().callEvent(new net.md_5.bungee.api.event.TabCompleteEvent(
                 snap.getPlayer(event.getPlayer()),
@@ -19,8 +36,9 @@ public class TabCompleteListener extends ForwardingListener {
                 event.getPartialMessage(),
                 event.getSuggestions()
         ));
-        if (e.isCancelled()) {
-            event.getSuggestions().clear();
+        event.getSuggestions().clear();
+        if (!e.isCancelled()) {
+            event.getSuggestions().addAll(e.getSuggestions());
         }
     }
 }

--- a/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteResponseListener.java
+++ b/src/main/java/de/themoep/snap/forwarding/listener/TabCompleteResponseListener.java
@@ -30,15 +30,16 @@ public class TabCompleteResponseListener extends ForwardingListener {
         super(snap, TabCompleteResponseEvent.class);
     }
 
-    @Subscribe
+    @Subscribe(priority = 5)
     public void on(TabCompleteEvent event) {
         TabCompleteResponseEvent e = snap.getBungeeAdapter().getPluginManager().callEvent(new TabCompleteResponseEvent(
                 event.getPlayer().getCurrentServer().map(s -> new SnapServer(snap, s)).orElse(null),
                 snap.getPlayer(event.getPlayer()),
                 event.getSuggestions()
         ));
-        if (e.isCancelled()) {
-            event.getSuggestions().clear();
+        event.getSuggestions().clear();
+        if (!e.isCancelled()) {
+            event.getSuggestions().addAll(e.getSuggestions());
         }
     }
 }

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -3,5 +3,5 @@
   "name": "Snap",
   "version": "${minecraft.plugin.version}",
   "main": "de.themoep.snap.Snap",
-  "authors": ["Phoenix616"]
+  "authors": ["Phoenix616", "tush2912"]
 }


### PR DESCRIPTION
Fixes #54

This PR modernizes the plugin to run natively on Java 21 and Velocity 3.5.0+.

It includes three main fixes:
- **Dependency Upgrades**: Bumps SnakeYAML and others for Java 21 compatibility.
- **TabCompleteEvent**: Restores missing auto-completion routing.
- **Issue #54 Target Server Fix**: Resolves crashes by using Velocity's native `.constructServerInfo` to ensure `ServerConnectEvent` always has a valid target server.
